### PR TITLE
Avoid calling next() in case of an error

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -40,9 +40,6 @@ class KoaJoiValidatorMiddleware {
   }
 
   _handleValidationError(ctx, next, error) {
-    if (error instanceof Joi.ValidationError === false) {
-      throw error;
-    }
     if (typeof this.onError === 'string') {
       throw new Error(this.onError);
     } else if (typeof this.onError === 'function') {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -43,7 +43,7 @@ class KoaJoiValidatorMiddleware {
     if (typeof this.onError === 'string') {
       throw new Error(this.onError);
     } else if (typeof this.onError === 'function') {
-      this.onError(ctx, next, error);
+      return this.onError(ctx, next, error);
     }
   }
 }

--- a/src/middleware.spec.js
+++ b/src/middleware.spec.js
@@ -51,6 +51,14 @@ describe('koaJoiValidatorMiddleware', () => {
       await expect(middleware(fakeInvalidCtx, fakeNext)).to.be.rejectedWith(customError);
     });
 
+    it('should not call next in case of a custom error handler function', async () => {
+      const next = global.sandbox.stub();
+
+      const middleware = middlewareFactory(schema, { onError: () => {} });
+      await middleware(fakeInvalidCtx, next);
+      expect(next).to.have.not.been.called;
+    });
+
     it('should call onError function if body is invalid with given schema', async () => {
       const customErrorSpy = global.sandbox.spy();
       const validationError = schema.validate(fakeInvalidCtx.request.body);


### PR DESCRIPTION
It might be a faulty use-case to neither throw an exception from the error handler, nor call the next middleware. But I also don't see any meaningful use-case for calling next() automatically once it has been passed to the error handler function, so I think flexibility is a plus here :) 